### PR TITLE
Fix endless loop in kfree.

### DIFF
--- a/src/kernel/mem.c
+++ b/src/kernel/mem.c
@@ -181,5 +181,6 @@ void kfree(void *ptr) {
         seg->next->next->prev = seg;
         seg->next = seg->next->next;
         seg->segment_size += seg->next->segment_size;
+        seg = seg->next;
     }
 }


### PR DESCRIPTION
Fixes dead code in `mem.c` by adding:
`seg = seg->next;` to `kfree`